### PR TITLE
fix(release): pin cosign to legacy bundle format

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -56,6 +56,7 @@ signs:
     args:
       - sign-blob
       - "--yes"
+      - "--new-bundle-format=false"
       - "--output-certificate=${certificate}"
       - "--output-signature=${signature}"
       - "${artifact}"


### PR DESCRIPTION
## Summary

\`v0.1.0\` упал на шаге cosign:

\`\`\`
Error: signing dist/checksums.txt: create bundle file: open : no such file or directory
\`\`\`

Cosign 2.5+ по умолчанию включил \`--new-bundle-format\` и стал игнорировать \`--output-signature\`/\`--output-certificate\`, которые наша конфигурация \`signs:\` использует для разделённых \`.sig\`/\`.pem\`. Без явного \`--bundle <path>\` cosign пытается открыть пустой путь и падает. Сам action \`sigstore/cosign-installer\` тянет \`latest\` — релизы \`jtgpwgen v0.3.0\` (2026-05-15) и предыдущие наши прогоны успели проскочить до бампа.

Минимальный фикс: добавить \`--new-bundle-format=false\` в \`signs.args\` — cosign продолжит писать раздельные артефакты, как ожидает goreleaser. Миграция на новый bundle-формат — отдельной задачей.

## Test plan

- [x] \`goreleaser check\` локально — валиден
- [ ] CI зелёный на PR
- [ ] После мержа: \`v0.1.0\` пересоздан, \`release.yml\` отрабатывает до конца (artifacts + cosign sigs + cask publish в \`jtprogru/homebrew-tap\`)