### PR TITLE
fix(release): migrate cosign signing to new bundle format

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -51,14 +51,11 @@ sboms:
 signs:
   - id: cosign-checksum
     cmd: cosign
-    signature: "${artifact}.sig"
-    certificate: "${artifact}.pem"
+    signature: "${artifact}.bundle"
     args:
       - sign-blob
       - "--yes"
-      - "--new-bundle-format=false"
-      - "--output-certificate=${certificate}"
-      - "--output-signature=${signature}"
+      - "--bundle=${signature}"
       - "${artifact}"
     artifacts: checksum
     output: true


### PR DESCRIPTION
## Summary

Прошлый фикс (\`fix/cosign-new-bundle-format\`, PR #9) с \`--new-bundle-format=false\` тоже упал — cosign 2.5+ полностью убрал fallback на разделённые \`.sig\`/\`.pem\` и теперь требует:

\`\`\`
must provide --new-bundle-format or --bundle where applicable with --signing-config or --use-signing-config
\`\`\`

\`--signing-config\` нужен для offline-ключей; у нас keyless через Sigstore OIDC, так что единственный путь — мигрировать на \`--bundle\`. Bundle это один файл, включающий подпись, сертификат и transparency-log entry. Это рекомендуемый Sigstore-формат.

## Что меняется

- \`signs.args\` теперь: \`--bundle=\${signature}\` вместо \`--output-certificate\` + \`--output-signature\`
- \`signature\` теперь \`\${artifact}.bundle\`
- Поле \`certificate:\` удалено (не нужно для bundle)
- В Release будет \`checksums.txt.bundle\` вместо \`checksums.txt.sig\` + \`checksums.txt.pem\`
- Верификация: \`cosign verify-blob --bundle=checksums.txt.bundle checksums.txt\`

## Test plan

- [x] \`goreleaser check\` локально — валиден
- [ ] CI зелёный на PR
- [ ] После мержа: \`v0.1.0\` пересоздан, релиз доходит до конца, cask публикуется в \`jtprogru/homebrew-tap\`