### PR TITLE
fix(tui): chain quick entry reload to avoid stale list

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -174,12 +174,14 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		raw := msg.raw
 		svc := m.service
 		return m, func() tea.Msg {
-			_, err := svc.QuickEntry(context.Background(), raw)
-			if err != nil {
+			if _, err := svc.QuickEntry(context.Background(), raw); err != nil {
 				return errorMsg{err}
 			}
-			return nil
+			return quickEntryDoneMsg{}
 		}
+
+	case quickEntryDoneMsg:
+		return m, tea.Batch(m.loadCurrentList(), fetchListCounts(m.service))
 
 	case editorSavedMsg:
 		m.screen = screenList
@@ -387,10 +389,7 @@ func (m Model) handleQuickEntryKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if m.blockWriteIfReadOnly() {
 			return m, tea.Tick(statusFadeDuration, func(time.Time) tea.Msg { return clearStatusMsg{} })
 		}
-		return m, tea.Batch(
-			func() tea.Msg { return quickEntrySubmittedMsg{raw: raw} },
-			m.loadCurrentList(),
-		)
+		return m, func() tea.Msg { return quickEntrySubmittedMsg{raw: raw} }
 	default:
 		var cmd tea.Cmd
 		m.quickInput, cmd = m.quickInput.Update(msg)

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -100,6 +100,83 @@ func TestTUI_QuickEntryHotkeyOpensModal(t *testing.T) {
 	require.Equal(t, screenQuickEntry, m2.(Model).screen)
 }
 
+// TestTUI_QuickEntrySubmitReloadsList verifies that after submitting a
+// new task via quick entry, m.tasks contains it without a tab switch.
+// Pre-fix: tea.Batch ran write + load concurrently and the load
+// sometimes finished before the write commit, leaving the list stale.
+// Now: write Cmd returns quickEntryDoneMsg, whose handler chains the
+// reload — guaranteed ordering, no race.
+func TestTUI_QuickEntrySubmitReloadsList(t *testing.T) {
+	m, svc, _ := setupModelWithInboxTasks(t, "existing one")
+
+	m2, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}})
+	mm := m2.(Model)
+	require.Equal(t, screenQuickEntry, mm.screen)
+	mm.quickInput.SetValue("freshly added")
+
+	m3, cmd := mm.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	mm = m3.(Model)
+	require.Equal(t, screenList, mm.screen)
+	require.NotNil(t, cmd, "submit must produce a Cmd")
+
+	// First Cmd emits quickEntrySubmittedMsg (key handler → submit message).
+	submitMsg := cmd()
+	require.IsType(t, quickEntrySubmittedMsg{}, submitMsg)
+
+	// Submit handler issues a Cmd that performs the QuickEntry write and
+	// produces quickEntryDoneMsg only after it commits — no concurrent reload.
+	m4, writeCmd := mm.Update(submitMsg)
+	mm = m4.(Model)
+	require.NotNil(t, writeCmd)
+	doneMsg := writeCmd()
+	require.IsType(t, quickEntryDoneMsg{}, doneMsg, "write Cmd must signal completion only after commit")
+
+	// Done-msg handler must chain reload + counts via tea.Batch.
+	m5, reloadCmd := mm.Update(doneMsg)
+	mm = m5.(Model)
+	require.NotNil(t, reloadCmd, "done msg handler must chain loadCurrentList")
+
+	// Drain the batched commands until the tasks-loaded message surfaces.
+	require.Eventually(t, func() bool {
+		msg := reloadCmd()
+		if loaded, ok := msg.(tasksLoadedMsg); ok {
+			mm.tasks = loaded.tasks
+			return true
+		}
+		// If we got a batch of msgs, fan them out and look for tasksLoadedMsg.
+		if batch, ok := msg.(tea.BatchMsg); ok {
+			for _, c := range batch {
+				if c == nil {
+					continue
+				}
+				if l, ok := c().(tasksLoadedMsg); ok {
+					mm.tasks = l.tasks
+					return true
+				}
+			}
+		}
+		return false
+	}, 2*time.Second, 10*time.Millisecond)
+
+	titles := make([]string, 0, len(mm.tasks))
+	for _, t := range mm.tasks {
+		titles = append(titles, t.Title)
+	}
+	require.Contains(t, titles, "freshly added", "new task must appear in m.tasks without a tab switch")
+
+	// Sanity: it's also in storage.
+	inbox, err := svc.ListInbox(context.Background())
+	require.NoError(t, err)
+	var found bool
+	for _, t := range inbox {
+		if t.Title == "freshly added" {
+			found = true
+			break
+		}
+	}
+	require.True(t, found)
+}
+
 func TestTUI_QuickEntryEscapeCloses(t *testing.T) {
 	m := newTestModel(t)
 	m2, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}})

--- a/internal/tui/msgs.go
+++ b/internal/tui/msgs.go
@@ -17,6 +17,11 @@ type clearStatusMsg struct{}
 
 type quickEntrySubmittedMsg struct{ raw string }
 
+// quickEntryDoneMsg is emitted after QuickEntry's service write commits.
+// The Update handler chains loadCurrentList + fetchListCounts so the new
+// task is reflected in m.tasks without a tab switch.
+type quickEntryDoneMsg struct{}
+
 type screenKind int
 
 const (


### PR DESCRIPTION
## Summary
Quick entry submit had a race: `handleQuickEntryKey` returned `tea.Batch(quickEntrySubmittedMsg, loadCurrentList)` — the write and the read ran concurrently as separate goroutines. When the reader hit bbolt before the writer committed, the loaded list omitted the new task, and the user had to switch tabs to see it appear.

The fix follows the v0.7.1 `singleActionDoneMsg` pattern: the key handler only emits `quickEntrySubmittedMsg`; its handler returns a Cmd that calls `QuickEntry` and emits the new `quickEntryDoneMsg` only after the write returns; `quickEntryDoneMsg`'s handler chains `loadCurrentList + fetchListCounts`. No more concurrent reads against an uncommitted write.

## Test plan
- [x] `task test` — passes
- [x] `task test-race` — race-free
- [x] `task build` — bin/todushka compiles
- [x] `task lint` — 0 issues
- [x] New `TestTUI_QuickEntrySubmitReloadsList` walks the full Cmd chain and verifies the new task is in `m.tasks` after the chain settles, without a tab switch