### PR TITLE
fix(tui): line-space viewport windowing — actually fix BL-7

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -60,10 +60,6 @@ type Model struct {
 	projectTasks        []task.Task
 	projectEditor       ProjectEditorModel
 	editingProject      bool
-
-	// Viewport scroll state (BL-7)
-	scrollOffset        int
-	projectScrollOffset int
 }
 
 // allLists is the canonical order used by Tab/Shift+Tab cycling and the header.
@@ -124,7 +120,6 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.cursor >= len(m.tasks) {
 			m.cursor = max(0, len(m.tasks)-1)
 		}
-		m.scrollOffset = ensureCursorVisible(m.cursor, m.scrollOffset, visibleRows(m), scrolloff, len(displayedTasks(m)))
 		return m, tea.Batch(
 			fetchNameCache(m.service, m.tasks),
 			fetchListCounts(m.service),
@@ -147,7 +142,6 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.projectCursor >= len(displayedProjects(m)) {
 			m.projectCursor = max(0, len(displayedProjects(m))-1)
 		}
-		m.projectScrollOffset = ensureCursorVisible(m.projectCursor, m.projectScrollOffset, visibleRows(m), scrolloff, len(displayedProjects(m)))
 		return m, fetchAreaNames(m.service, areaIDs)
 
 	case projectTasksLoadedMsg:
@@ -162,7 +156,6 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.cursor >= len(msg.tasks) {
 			m.cursor = max(0, len(msg.tasks)-1)
 		}
-		m.scrollOffset = ensureCursorVisible(m.cursor, m.scrollOffset, visibleRows(m), scrolloff, len(displayedTasks(m)))
 		return m, fetchNameCache(m.service, msg.tasks)
 
 	case projectSavedMsg:
@@ -308,7 +301,6 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case key.Matches(msg, m.keys.Projects):
 		m.screen = screenProjects
 		m.projectCursor = 0
-		m.projectScrollOffset = 0
 		m.filterQuery = ""
 		m.filtering = false
 		return m, fetchProjects(m.service, m.projectStatusFilter == psfAll)
@@ -347,13 +339,11 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if m.cursor > 0 {
 			m.cursor--
 		}
-		m.scrollOffset = ensureCursorVisible(m.cursor, m.scrollOffset, visibleRows(m), scrolloff, len(displayedTasks(m)))
 		return m, nil
 	case key.Matches(msg, m.keys.Down):
 		if m.cursor < len(m.tasks)-1 {
 			m.cursor++
 		}
-		m.scrollOffset = ensureCursorVisible(m.cursor, m.scrollOffset, visibleRows(m), scrolloff, len(displayedTasks(m)))
 		return m, nil
 	case key.Matches(msg, m.keys.Enter):
 		return m.openEditor()
@@ -483,26 +473,22 @@ func (m Model) handleProjectsKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case key.Matches(msg, m.keys.CloseModal):
 		m.screen = screenList
 		m.projectCursor = 0
-		m.projectScrollOffset = 0
 		m.filterQuery = ""
 		return m, nil
 	case key.Matches(msg, m.keys.Projects):
 		m.screen = screenList
 		m.projectCursor = 0
-		m.projectScrollOffset = 0
 		m.filterQuery = ""
 		return m, nil
 	case key.Matches(msg, m.keys.Up):
 		if m.projectCursor > 0 {
 			m.projectCursor--
 		}
-		m.projectScrollOffset = ensureCursorVisible(m.projectCursor, m.projectScrollOffset, visibleRows(m), scrolloff, len(displayedProjects(m)))
 		return m, nil
 	case key.Matches(msg, m.keys.Down):
 		if m.projectCursor < len(displayedProjects(m))-1 {
 			m.projectCursor++
 		}
-		m.projectScrollOffset = ensureCursorVisible(m.projectCursor, m.projectScrollOffset, visibleRows(m), scrolloff, len(displayedProjects(m)))
 		return m, nil
 	case key.Matches(msg, m.keys.Filter):
 		m.filtering = true
@@ -514,7 +500,6 @@ func (m Model) handleProjectsKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		} else {
 			m.projectStatusFilter = psfOpen
 		}
-		m.projectScrollOffset = 0
 		return m, fetchProjects(m.service, m.projectStatusFilter == psfAll)
 	case key.Matches(msg, m.keys.QuickEntry):
 		// 'n' in screenProjects = new project (REQ-3.1).
@@ -558,7 +543,6 @@ func (m Model) handleProjectsKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.screen = screenProjectTasks
 		m.activeProjectID = &pid
 		m.cursor = 0
-		m.scrollOffset = 0
 		m.filterQuery = ""
 		m.filtering = false
 		m.selected = make(map[id.ID]struct{})
@@ -604,7 +588,6 @@ func (m Model) handleProjectTasksKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.projectTasks = nil
 		m.tasks = nil
 		m.cursor = 0
-		m.scrollOffset = 0
 		m.selected = make(map[id.ID]struct{})
 		return m, fetchProjects(m.service, m.projectStatusFilter == psfAll)
 	}
@@ -641,13 +624,11 @@ func (m Model) handleProjectTasksKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if m.cursor > 0 {
 			m.cursor--
 		}
-		m.scrollOffset = ensureCursorVisible(m.cursor, m.scrollOffset, visibleRows(m), scrolloff, len(displayedTasks(m)))
 		return m, nil
 	case key.Matches(msg, m.keys.Down):
 		if m.cursor < len(m.tasks)-1 {
 			m.cursor++
 		}
-		m.scrollOffset = ensureCursorVisible(m.cursor, m.scrollOffset, visibleRows(m), scrolloff, len(displayedTasks(m)))
 		return m, nil
 	case key.Matches(msg, m.keys.Enter):
 		return m.openEditor()
@@ -725,7 +706,6 @@ func (m Model) switchList(l listKind) (tea.Model, tea.Cmd) {
 	m.selected = make(map[id.ID]struct{})
 	m.activeList = l
 	m.cursor = 0
-	m.scrollOffset = 0
 	return m, m.loadCurrentList()
 }
 
@@ -1002,28 +982,14 @@ func (m Model) viewList() string {
 	if isDualPane(m) {
 		paneWidth, _ = paneWidths(m)
 	}
-	// Apply viewport scroll (BL-7).
-	vr := visibleRows(m)
-	off := m.scrollOffset
-	if vr > 0 && len(disp) > vr {
-		if off > len(disp)-vr {
-			off = len(disp) - vr
-		}
-		if off < 0 {
-			off = 0
-		}
-		end := off + vr
-		if end > len(disp) {
-			end = len(disp)
-		}
-		disp = disp[off:end]
-	} else {
-		off = 0
-	}
-	lines := make([]string, 0, len(disp))
+	// Render every task row and remember which line in the output
+	// hosts the cursor's first line. Windowing then happens in line
+	// space (BL-7): logical-row scroll is incorrect when titles wrap
+	// because lipgloss MaxHeight clamps the rendered string by lines.
+	var lines []string
+	cursorLineIdx := -1
 	showPrefix := len(m.selected) > 0
 	for i, t := range disp {
-		absIdx := i + off
 		prefix := ""
 		if showPrefix {
 			if _, ok := m.selected[t.ID]; ok {
@@ -1033,7 +999,7 @@ func (m Model) viewList() string {
 			}
 		}
 		marker := "  "
-		if absIdx == m.cursor {
+		if i == m.cursor {
 			marker = m.theme.Selected.Render("> ")
 		}
 		icon := "  "
@@ -1062,10 +1028,13 @@ func (m Model) viewList() string {
 			}
 		}
 
+		if i == m.cursor {
+			cursorLineIdx = len(lines)
+		}
 		lines = append(lines, firstLinePrefix+titleLines[0])
 		lines = append(lines, titleLines[1:]...)
 	}
-	return strings.Join(lines, "\n")
+	return windowLines(lines, cursorLineIdx, visibleRows(m), scrolloff)
 }
 
 func (m Model) viewQuickEntry() string {

--- a/internal/tui/project_list.go
+++ b/internal/tui/project_list.go
@@ -106,30 +106,15 @@ func viewProjectList(m Model, width int) string {
 		return header + m.theme.Dim.Render("\n  (no projects)\n")
 	}
 
-	// Apply viewport scroll (BL-7). Header + blank line occupy 2 rows.
-	vr := visibleRows(m) - 2
-	off := m.projectScrollOffset
-	if vr > 0 && len(disp) > vr {
-		if off > len(disp)-vr {
-			off = len(disp) - vr
-		}
-		if off < 0 {
-			off = 0
-		}
-		end := off + vr
-		if end > len(disp) {
-			end = len(disp)
-		}
-		disp = disp[off:end]
-	} else {
-		off = 0
-	}
-
-	lines := []string{header, ""}
+	// Build row-by-row, track cursor line, then window in line space (BL-7).
+	rowLines := []string{}
+	cursorLineIdx := -1
 	for i, p := range disp {
-		absIdx := i + off
+		if i == m.projectCursor {
+			cursorLineIdx = len(rowLines)
+		}
 		marker := "  "
-		if absIdx == m.projectCursor {
+		if i == m.projectCursor {
 			marker = m.theme.Selected.Render("> ")
 		}
 		icon := projectStatusIcon(m.theme, p.Status) + " "
@@ -153,7 +138,9 @@ func viewProjectList(m Model, width int) string {
 		}
 
 		row := fmt.Sprintf("%s%s%s  %s%s%s%s", marker, icon, short, p.Name, countsStr, areaStr, deadlineStr)
-		lines = append(lines, row)
+		rowLines = append(rowLines, row)
 	}
-	return lipgloss.JoinVertical(lipgloss.Left, lines...)
+	// Header + blank line consume 2 of visibleRows.
+	body := windowLines(rowLines, cursorLineIdx, visibleRows(m)-2, scrolloff)
+	return lipgloss.JoinVertical(lipgloss.Left, header, "", body)
 }

--- a/internal/tui/project_tasks.go
+++ b/internal/tui/project_tasks.go
@@ -51,29 +51,15 @@ func viewProjectTasks(m Model, width int) string {
 		}
 		return header + "\n" + m.theme.Dim.Render("  (no tasks in this project)")
 	}
-	// Apply viewport scroll (BL-7). Header + blank line occupy 2 rows.
-	vr := visibleRows(m) - 2
-	off := m.scrollOffset
-	if vr > 0 && len(disp) > vr {
-		if off > len(disp)-vr {
-			off = len(disp) - vr
-		}
-		if off < 0 {
-			off = 0
-		}
-		end := off + vr
-		if end > len(disp) {
-			end = len(disp)
-		}
-		disp = disp[off:end]
-	} else {
-		off = 0
-	}
-	lines := []string{header, ""}
+	// Build row-by-row, track cursor line, then window in line space (BL-7).
+	rowLines := []string{}
+	cursorLineIdx := -1
 	for i, t := range disp {
-		absIdx := i + off
+		if i == m.cursor {
+			cursorLineIdx = len(rowLines)
+		}
 		marker := "  "
-		if absIdx == m.cursor {
+		if i == m.cursor {
 			marker = m.theme.Selected.Render("> ")
 		}
 		icon := "  "
@@ -93,11 +79,12 @@ func viewProjectTasks(m Model, width int) string {
 			}
 		}
 		row := fmt.Sprintf("%s%s%s  %s", marker, icon, short, title)
-		lines = append(lines, row)
+		rowLines = append(rowLines, row)
 	}
-	return lipgloss.JoinVertical(lipgloss.Left, lines...)
+	// Header + blank line consume 2 of visibleRows.
+	body := windowLines(rowLines, cursorLineIdx, visibleRows(m)-2, scrolloff)
+	return lipgloss.JoinVertical(lipgloss.Left, header, "", body)
 }
 
-// keep strings import to satisfy go vet for indirect TrimSpace usage
-// (handleFilterKey is in a sibling file and reaches into m.filterQuery).
 var _ = strings.TrimSpace
+var _ = lipgloss.JoinVertical

--- a/internal/tui/viewport.go
+++ b/internal/tui/viewport.go
@@ -1,65 +1,66 @@
 package tui
 
-import "github.com/charmbracelet/lipgloss"
+import (
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+)
 
 // scrolloff is the minimum number of rows kept visible above and below
 // the cursor before the viewport starts following it. Mirrors vim's
 // `scrolloff=3` default.
 const scrolloff = 3
 
-// ensureCursorVisible returns a new scrollOffset such that `cursor` is
-// rendered within the window [offset, offset+visibleCount), with at
-// least `scrolloff` rows of buffer above and below (clamped by the list
-// ends and the visibleCount).
+// windowLines returns a slice of `lines` of length up to `visibleRows`
+// that contains `cursorLineIdx` with at least `scrolloff` lines of
+// buffer above and below (clamped by the start/end of `lines`).
+// When `visibleRows <= 0` or `len(lines) <= visibleRows`, the entire
+// list is joined (no truncation). When `cursorLineIdx < 0` (cursor
+// not in current view), the window is taken from the start.
 //
-//   - If visibleCount <= 0 or totalCount <= visibleCount, the result is 0:
-//     everything fits or nothing renders.
-//   - If cursor < 0, it is treated as 0 (defensive).
-//   - The returned offset is always clamped to [0, max(0, totalCount-visibleCount)].
-func ensureCursorVisible(cursor, offset, visibleCount, scrolloff, totalCount int) int {
-	if visibleCount <= 0 {
-		return 0
+// Line-space windowing is the correct model for the renderer because
+// lipgloss `MaxHeight` clamps the body by lines, not by logical rows;
+// when titles wrap into multiple lines a logical-row offset can place
+// the cursor row past the clamp.
+func windowLines(lines []string, cursorLineIdx, visibleRows, scrolloff int) string {
+	if visibleRows <= 0 || len(lines) <= visibleRows {
+		return strings.Join(lines, "\n")
 	}
-	if totalCount <= visibleCount {
-		return 0
+	if cursorLineIdx < 0 {
+		return strings.Join(lines[:visibleRows], "\n")
 	}
-	if cursor < 0 {
-		cursor = 0
+	start := cursorLineIdx - scrolloff
+	if start < 0 {
+		start = 0
 	}
-	if cursor >= totalCount {
-		cursor = totalCount - 1
+	end := start + visibleRows
+	if end > len(lines) {
+		end = len(lines)
+		start = end - visibleRows
+		if start < 0 {
+			start = 0
+		}
 	}
-	maxOffset := totalCount - visibleCount
-
-	// Hard bounds — cursor must be inside [offset, offset+visibleCount).
-	// These also dominate when visibleCount < 2*scrolloff+1 (narrow window
-	// where both buffer rules would otherwise conflict).
-	minOffset := cursor - visibleCount + 1
-	if minOffset < 0 {
-		minOffset = 0
+	// Hard-bounds re-anchor — guarantees cursor visible even when the
+	// window is narrower than the buffer (visibleRows < 2*scrolloff+1).
+	if cursorLineIdx >= end {
+		end = cursorLineIdx + 1
+		if end > len(lines) {
+			end = len(lines)
+		}
+		start = end - visibleRows
+		if start < 0 {
+			start = 0
+		}
 	}
-	maxOffsetForCursor := cursor
-	if maxOffsetForCursor > maxOffset {
-		maxOffsetForCursor = maxOffset
+	if cursorLineIdx < start {
+		start = cursorLineIdx
+		end = start + visibleRows
+		if end > len(lines) {
+			end = len(lines)
+		}
 	}
-
-	// Top buffer: cursor approaching the top of the window.
-	if cursor-offset < scrolloff {
-		offset = cursor - scrolloff
-	}
-	// Bottom buffer: cursor approaching the bottom of the window.
-	if cursor-offset > visibleCount-1-scrolloff {
-		offset = cursor - visibleCount + 1 + scrolloff
-	}
-
-	// Clamp into [minOffset, maxOffsetForCursor]: guarantees cursor visible.
-	if offset < minOffset {
-		offset = minOffset
-	}
-	if offset > maxOffsetForCursor {
-		offset = maxOffsetForCursor
-	}
-	return offset
+	return strings.Join(lines[start:end], "\n")
 }
 
 // visibleRows reports how many list rows can be rendered in the body

--- a/internal/tui/viewport_test.go
+++ b/internal/tui/viewport_test.go
@@ -1,280 +1,258 @@
 package tui
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
 	"github.com/jtprogru/todushka/internal/domain/id"
 	"github.com/jtprogru/todushka/internal/domain/project"
 	"github.com/jtprogru/todushka/internal/domain/task"
+	"github.com/muesli/termenv"
 	"github.com/stretchr/testify/require"
 	"pgregory.net/rapid"
 )
 
-// ─── T-1.1: exploration test that reproduces BL-7 ────────────────────
+// ─── windowLines unit tests ──────────────────────────────────────────
 
-// TestModel_CursorInvisibleOnOverflow demonstrates the bug: with 30 tasks
-// and a small terminal (height=12 → visibleRows around 8), pressing j 20
-// times moves m.cursor to 20, but the renderer must keep that cursor
-// inside the visible window. Before the fix, m.scrollOffset doesn't exist
-// and the cursor "leaves" the screen.
-func TestModel_CursorInvisibleOnOverflow(t *testing.T) {
+func TestWindowLines_FitsInVisible(t *testing.T) {
+	got := windowLines([]string{"a", "b", "c"}, 1, 10, 3)
+	require.Equal(t, "a\nb\nc", got)
+}
+
+func TestWindowLines_VisibleZero(t *testing.T) {
+	got := windowLines([]string{"a", "b", "c"}, 1, 0, 3)
+	require.Equal(t, "a\nb\nc", got)
+}
+
+func TestWindowLines_CursorMissing(t *testing.T) {
+	got := windowLines([]string{"a", "b", "c", "d", "e"}, -1, 2, 3)
+	require.Equal(t, "a\nb", got)
+}
+
+func TestWindowLines_CursorAtStart(t *testing.T) {
+	// 20 lines, visible=10, cursor at line 0, scrolloff=3.
+	lines := make([]string, 20)
+	for i := range lines {
+		lines[i] = fmt.Sprintf("L%02d", i)
+	}
+	got := windowLines(lines, 0, 10, 3)
+	// Window should be lines[0:10].
+	require.Equal(t, strings.Join(lines[0:10], "\n"), got)
+}
+
+func TestWindowLines_CursorAtEnd(t *testing.T) {
+	// 20 lines, visible=10, cursor at line 19.
+	lines := make([]string, 20)
+	for i := range lines {
+		lines[i] = fmt.Sprintf("L%02d", i)
+	}
+	got := windowLines(lines, 19, 10, 3)
+	// Cursor at end → window anchored to end: lines[10:20].
+	require.Equal(t, strings.Join(lines[10:20], "\n"), got)
+}
+
+func TestWindowLines_CursorInMiddle(t *testing.T) {
+	lines := make([]string, 20)
+	for i := range lines {
+		lines[i] = fmt.Sprintf("L%02d", i)
+	}
+	// Cursor at line 10, scrolloff=3 → window starts at 10-3=7, ends at 17.
+	got := windowLines(lines, 10, 10, 3)
+	require.Equal(t, strings.Join(lines[7:17], "\n"), got)
+}
+
+func TestWindowLines_NarrowVisible(t *testing.T) {
+	lines := []string{"a", "b", "c", "d", "e"}
+	got := windowLines(lines, 3, 1, 3) // visible=1, scrolloff=3 — narrow window
+	require.Equal(t, "d", got, "narrow window must still contain cursor line")
+}
+
+func TestProp_WindowLines_CursorAlwaysInside(t *testing.T) {
+	rapid.Check(t, func(rt *rapid.T) {
+		total := rapid.IntRange(1, 100).Draw(rt, "total")
+		visible := rapid.IntRange(1, 50).Draw(rt, "visible")
+		cursor := rapid.IntRange(0, total-1).Draw(rt, "cursor")
+		lines := make([]string, total)
+		for i := range lines {
+			lines[i] = fmt.Sprintf("L%03d", i)
+		}
+		out := windowLines(lines, cursor, visible, 3)
+		require.Contains(rt, out, fmt.Sprintf("L%03d", cursor),
+			"cursor's line must be present in windowed output")
+	})
+}
+
+// ─── Real-render integration tests: assert cursor marker visible ────
+
+// findCursorLine returns the line in `out` that starts with the cursor
+// marker `> `, or empty string if not found. Lines are split on '\n'.
+// Output is assumed to have ANSI styling stripped (termenv.Ascii).
+func findCursorLine(out string) string {
+	for _, ln := range strings.Split(out, "\n") {
+		trimmed := strings.TrimLeft(ln, " ")
+		if strings.HasPrefix(trimmed, "> ") {
+			return ln
+		}
+	}
+	return ""
+}
+
+func TestModel_ViewList_CursorInRenderedOutput_NoWrap(t *testing.T) {
+	lipgloss.SetColorProfile(termenv.Ascii)
+	t.Cleanup(func() { lipgloss.SetColorProfile(termenv.Ascii) })
+
 	m := newTestModel(t)
-	m.height = 12 // small terminal
+	m.height = 20
 	m.width = 80
-	// Populate 30 tasks.
 	tasks := make([]task.Task, 30)
 	for i := range tasks {
-		tasks[i] = task.Task{ID: id.New(), Title: "t", Status: task.StatusOpen}
+		tasks[i] = task.Task{ID: id.New(), Title: fmt.Sprintf("task-%02d", i), Status: task.StatusOpen}
 	}
 	m.tasks = tasks
-
-	// Press 'j' 20 times.
 	for i := 0; i < 20; i++ {
 		mm, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
 		m = mm.(Model)
 	}
 	require.Equal(t, 20, m.cursor)
-	vr := visibleRows(m)
-	require.Greater(t, vr, 0, "visibleRows must be positive at height=12")
-	// After fix: cursor must be inside the visible window [offset, offset+vr).
-	require.GreaterOrEqual(t, m.cursor, m.scrollOffset,
-		"cursor must be >= scrollOffset (would mean cursor is above window)")
-	require.Less(t, m.cursor, m.scrollOffset+vr,
-		"cursor must be < scrollOffset+visibleRows (would mean cursor is below window)")
+	line := findCursorLine(m.View())
+	require.NotEmpty(t, line)
+	require.Contains(t, line, "task-20")
 }
 
-// ─── T-1.2: ensureCursorVisible unit tests ──────────────────────────
+func TestModel_ViewList_CursorInRenderedOutput_LongTitlesWrap(t *testing.T) {
+	lipgloss.SetColorProfile(termenv.Ascii)
+	t.Cleanup(func() { lipgloss.SetColorProfile(termenv.Ascii) })
 
-func TestEnsureCursorVisible_FitsInVisible(t *testing.T) {
-	require.Equal(t, 0, ensureCursorVisible(2, 0, 10, 3, 5))
-}
-
-func TestEnsureCursorVisible_CursorAtStart(t *testing.T) {
-	require.Equal(t, 0, ensureCursorVisible(0, 0, 10, 3, 50))
-}
-
-func TestEnsureCursorVisible_CursorAtEnd(t *testing.T) {
-	// total=20, visible=10 → maxOffset=10. cursor=19 → must be at the bottom
-	// of the window, so offset should be 10 (cursor at index 9 within window).
-	require.Equal(t, 10, ensureCursorVisible(19, 0, 10, 3, 20))
-}
-
-func TestEnsureCursorVisible_CursorMovesDownIntoBuffer(t *testing.T) {
-	// total=20, visible=10, scrolloff=3. offset=0. cursor=7 → still has
-	// scrolloff (10-1-7 = 2 < 3) → must shift offset to keep 3 buffer.
-	// new offset = cursor - visible + 1 + scrolloff = 7 - 10 + 1 + 3 = 1.
-	got := ensureCursorVisible(7, 0, 10, 3, 20)
-	require.Equal(t, 1, got)
-}
-
-func TestEnsureCursorVisible_CursorMovesUpIntoBuffer(t *testing.T) {
-	// total=20, visible=10, scrolloff=3. offset=10, cursor=12.
-	// cursor - offset = 2 < scrolloff(3) → shift up: offset = cursor - scrolloff = 9.
-	require.Equal(t, 9, ensureCursorVisible(12, 10, 10, 3, 20))
-}
-
-func TestEnsureCursorVisible_ClampOnReload(t *testing.T) {
-	// offset=10, total shrinks to 5, visible=10 → maxOffset=0 → 0.
-	require.Equal(t, 0, ensureCursorVisible(2, 10, 10, 3, 5))
-}
-
-func TestEnsureCursorVisible_VisibleZero(t *testing.T) {
-	require.Equal(t, 0, ensureCursorVisible(5, 3, 0, 3, 20))
-}
-
-func TestEnsureCursorVisible_NegativeCursor(t *testing.T) {
-	require.Equal(t, 0, ensureCursorVisible(-1, 5, 10, 3, 20))
-}
-
-func TestEnsureCursorVisible_NoMovementWhenInBuffer(t *testing.T) {
-	// cursor=10, visible=10, offset=5 → cursor in [5,15), buffer
-	// 10-5=5 >= 3 and 14-10=4 >= 3 → no movement, return 5.
-	require.Equal(t, 5, ensureCursorVisible(10, 5, 10, 3, 20))
-}
-
-// ─── T-1.4: PBT for invariants ───────────────────────────────────────
-
-func TestProp_OffsetBounded(t *testing.T) {
-	rapid.Check(t, func(rt *rapid.T) {
-		total := rapid.IntRange(0, 100).Draw(rt, "total")
-		visible := rapid.IntRange(0, 50).Draw(rt, "visible")
-		cursor := rapid.IntRange(-5, 100).Draw(rt, "cursor")
-		off := rapid.IntRange(-5, 100).Draw(rt, "off")
-		got := ensureCursorVisible(cursor, off, visible, 3, total)
-		require.GreaterOrEqual(rt, got, 0)
-		maxOff := total - visible
-		if maxOff < 0 {
-			maxOff = 0
-		}
-		require.LessOrEqual(rt, got, maxOff,
-			"offset must be <= max(0, total-visible)")
-	})
-}
-
-func TestProp_CursorAlwaysInside(t *testing.T) {
-	rapid.Check(t, func(rt *rapid.T) {
-		total := rapid.IntRange(1, 100).Draw(rt, "total")
-		visible := rapid.IntRange(1, 50).Draw(rt, "visible")
-		cursor := rapid.IntRange(0, total-1).Draw(rt, "cursor")
-		off := rapid.IntRange(0, total).Draw(rt, "off")
-		got := ensureCursorVisible(cursor, off, visible, 3, total)
-		require.GreaterOrEqual(rt, cursor, got,
-			"cursor must be >= offset")
-		require.Less(rt, cursor, got+visible,
-			"cursor must be < offset + visible")
-	})
-}
-
-// ─── T-4: integration tests ──────────────────────────────────────────
-
-func TestModel_ViewList_CursorVisibleAfterJ(t *testing.T) {
 	m := newTestModel(t)
 	m.height = 20
 	m.width = 80
+	long := strings.Repeat("very long title text that definitely wraps ", 3)
 	tasks := make([]task.Task, 30)
 	for i := range tasks {
-		tasks[i] = task.Task{ID: id.New(), Title: "t", Status: task.StatusOpen}
+		tasks[i] = task.Task{ID: id.New(), Title: fmt.Sprintf("%02d %s", i, long), Status: task.StatusOpen}
 	}
 	m.tasks = tasks
 	for i := 0; i < 20; i++ {
 		mm, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
 		m = mm.(Model)
-		vr := visibleRows(m)
-		if vr <= 0 {
-			t.Fatalf("visibleRows=0 at iter=%d", i)
-		}
-		require.GreaterOrEqual(t, m.cursor, m.scrollOffset,
-			"cursor must be >= scrollOffset at iter=%d", i)
-		require.Less(t, m.cursor, m.scrollOffset+vr,
-			"cursor must be < scrollOffset+vr at iter=%d (cursor=%d, off=%d, vr=%d)",
-			i, m.cursor, m.scrollOffset, vr)
 	}
+	require.NotEmpty(t, findCursorLine(m.View()),
+		"cursor marker '> ' must be present in rendered output even with wrapping titles")
 }
 
-func TestModel_ViewProjectList_CursorVisibleAfterJ(t *testing.T) {
+func TestModel_ViewList_CursorInRenderedOutput_DualPane(t *testing.T) {
+	lipgloss.SetColorProfile(termenv.Ascii)
+	t.Cleanup(func() { lipgloss.SetColorProfile(termenv.Ascii) })
+
+	m := newTestModel(t)
+	m.height = 20
+	m.width = 150
+	tasks := make([]task.Task, 30)
+	for i := range tasks {
+		tasks[i] = task.Task{ID: id.New(), Title: fmt.Sprintf("task-%02d", i), Status: task.StatusOpen}
+	}
+	m.tasks = tasks
+	for i := 0; i < 20; i++ {
+		mm, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+		m = mm.(Model)
+	}
+	line := findCursorLine(m.View())
+	require.NotEmpty(t, line)
+	require.Contains(t, line, "task-20")
+}
+
+func TestModel_ViewList_CursorInRenderedOutput_SmallTerminal(t *testing.T) {
+	lipgloss.SetColorProfile(termenv.Ascii)
+	t.Cleanup(func() { lipgloss.SetColorProfile(termenv.Ascii) })
+
+	m := newTestModel(t)
+	m.height = 12
+	m.width = 60
+	tasks := make([]task.Task, 40)
+	for i := range tasks {
+		tasks[i] = task.Task{ID: id.New(), Title: fmt.Sprintf("task-%03d", i), Status: task.StatusOpen}
+	}
+	m.tasks = tasks
+	for i := 0; i < 30; i++ {
+		mm, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+		m = mm.(Model)
+	}
+	line := findCursorLine(m.View())
+	require.NotEmpty(t, line)
+	require.Contains(t, line, "task-030")
+}
+
+func TestModel_ViewProjectList_CursorInRenderedOutput(t *testing.T) {
+	lipgloss.SetColorProfile(termenv.Ascii)
+	t.Cleanup(func() { lipgloss.SetColorProfile(termenv.Ascii) })
+
 	m := newTestModel(t)
 	m.screen = screenProjects
 	m.height = 20
 	m.width = 80
-	projects := make([]projectStub, 30)
+	projects := make([]project.Project, 30)
 	for i := range projects {
-		projects[i] = newOpenProject()
+		projects[i] = project.Project{ID: id.New(), Name: fmt.Sprintf("proj-%02d", i), Status: project.StatusOpen}
 	}
-	m.projects = stubsToProjects(projects)
+	m.projects = projects
 	for i := 0; i < 20; i++ {
 		mm, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
 		m = mm.(Model)
-		// Account for "Projects" header + blank line consuming 2 rows.
-		vr := visibleRows(m) - 2
-		if vr <= 0 {
-			t.Skipf("visibleRows-header=%d <=0 at iter=%d", vr, i)
-		}
-		require.GreaterOrEqual(t, m.projectCursor, m.projectScrollOffset,
-			"projectCursor >= projectScrollOffset at iter=%d", i)
-		require.Less(t, m.projectCursor, m.projectScrollOffset+vr,
-			"projectCursor < projectScrollOffset+vr at iter=%d (cursor=%d, off=%d, vr=%d)",
-			i, m.projectCursor, m.projectScrollOffset, vr)
 	}
+	line := findCursorLine(m.View())
+	require.NotEmpty(t, line, "cursor marker must be present in screenProjects after 20×j")
+	require.Contains(t, line, "proj-20")
 }
 
-func TestModel_ViewProjectTasks_CursorVisibleAfterJ(t *testing.T) {
+func TestModel_ViewProjectTasks_CursorInRenderedOutput(t *testing.T) {
+	lipgloss.SetColorProfile(termenv.Ascii)
+	t.Cleanup(func() { lipgloss.SetColorProfile(termenv.Ascii) })
+
 	m := newTestModel(t)
+	pid := id.New()
+	m.screen = screenProjectTasks
+	m.activeProjectID = &pid
+	m.projects = []project.Project{{ID: pid, Name: "P", Status: project.StatusOpen}}
 	m.height = 20
 	m.width = 80
-	pid := id.New()
-	m.activeProjectID = &pid
-	m.screen = screenProjectTasks
 	tasks := make([]task.Task, 30)
 	for i := range tasks {
-		tasks[i] = task.Task{ID: id.New(), Title: "t", Status: task.StatusOpen}
+		tasks[i] = task.Task{ID: id.New(), Title: fmt.Sprintf("zoom-%02d", i), Status: task.StatusOpen}
 	}
 	m.tasks = tasks
 	m.projectTasks = tasks
 	for i := 0; i < 20; i++ {
 		mm, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
 		m = mm.(Model)
-		vr := visibleRows(m) - 2 // header+blank
-		if vr <= 0 {
-			t.Skipf("visibleRows-header=%d <=0 at iter=%d", vr, i)
-		}
-		require.GreaterOrEqual(t, m.cursor, m.scrollOffset)
-		require.Less(t, m.cursor, m.scrollOffset+vr)
 	}
+	line := findCursorLine(m.View())
+	require.NotEmpty(t, line, "cursor marker must be present in screenProjectTasks after 20×j")
+	require.Contains(t, line, "zoom-20")
 }
 
-func TestModel_ScrollOffsetResetOnSwitchList(t *testing.T) {
+func TestModel_ViewList_BodyLineCountBounded(t *testing.T) {
+	// After windowing, the body should not exceed the available rows
+	// (visibleRows). This prevents lipgloss MaxHeight from cutting any
+	// rendered content unexpectedly.
+	lipgloss.SetColorProfile(termenv.Ascii)
+	t.Cleanup(func() { lipgloss.SetColorProfile(termenv.Ascii) })
+
 	m := newTestModel(t)
-	m.height = 20
+	m.height = 15
 	m.width = 80
-	tasks := make([]task.Task, 30)
+	tasks := make([]task.Task, 50)
 	for i := range tasks {
-		tasks[i] = task.Task{ID: id.New(), Title: "t", Status: task.StatusOpen}
+		tasks[i] = task.Task{ID: id.New(), Title: fmt.Sprintf("task-%02d", i), Status: task.StatusOpen}
 	}
 	m.tasks = tasks
-	// Scroll down so offset > 0.
-	for i := 0; i < 20; i++ {
-		mm, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
-		m = mm.(Model)
-	}
-	require.Greater(t, m.scrollOffset, 0, "precondition: scrollOffset must be > 0")
-	// Switch list via Tab.
-	mm, _ := m.Update(tea.KeyMsg{Type: tea.KeyTab})
-	m = mm.(Model)
-	require.Equal(t, 0, m.scrollOffset, "switchList must reset scrollOffset")
-	require.Equal(t, 0, m.cursor, "switchList must reset cursor")
-}
-
-func TestModel_ScrollOffsetClampOnTasksReload(t *testing.T) {
-	m := newTestModel(t)
-	m.height = 20
-	m.width = 80
-	m.scrollOffset = 25 // pretend we were scrolled deep
 	m.cursor = 25
-	// Reload with a shorter list.
-	short := make([]task.Task, 5)
-	for i := range short {
-		short[i] = task.Task{ID: id.New(), Title: "t", Status: task.StatusOpen}
-	}
-	mm, _ := m.Update(tasksLoadedMsg{tasks: short})
-	m = mm.(Model)
-	// totalRows=5, visibleRows>5 → offset must collapse to 0.
-	require.Equal(t, 0, m.scrollOffset)
-	require.LessOrEqual(t, m.cursor, len(m.tasks)-1)
-}
 
-// Helpers for project stubs.
-
-type projectStub struct{ id id.ID }
-
-func newOpenProject() projectStub { return projectStub{id: id.New()} }
-
-func stubsToProjects(stubs []projectStub) []project.Project {
-	out := make([]project.Project, len(stubs))
-	for i, s := range stubs {
-		out[i] = project.Project{ID: s.id, Name: "p", Status: project.StatusOpen}
-	}
-	return out
-}
-
-func TestProp_ScrollOffBufferRespected(t *testing.T) {
-	rapid.Check(t, func(rt *rapid.T) {
-		// Pick params where buffer is meaningful: total > visible + 2*scrolloff.
-		visible := rapid.IntRange(10, 30).Draw(rt, "visible")
-		extra := rapid.IntRange(7, 50).Draw(rt, "extra") // > 2*scrolloff
-		total := visible + extra
-		cursor := rapid.IntRange(0, total-1).Draw(rt, "cursor")
-		off := rapid.IntRange(0, total).Draw(rt, "off")
-		got := ensureCursorVisible(cursor, off, visible, 3, total)
-		// Top buffer: cursor - got >= 3, unless cursor near list start (cursor < 3).
-		if cursor >= 3 {
-			require.GreaterOrEqual(rt, cursor-got, 3,
-				"top scrolloff buffer must be >= 3 when not near start")
-		}
-		// Bottom buffer: (got + visible - 1) - cursor >= 3, unless cursor near end.
-		if cursor < total-3 {
-			require.GreaterOrEqual(rt, (got+visible-1)-cursor, 3,
-				"bottom scrolloff buffer must be >= 3 when not near end")
-		}
-	})
+	body := m.viewList()
+	bodyLines := strings.Count(body, "\n") + 1
+	require.LessOrEqual(t, bodyLines, visibleRows(m),
+		"viewList body must not exceed visibleRows (%d), got %d lines",
+		visibleRows(m), bodyLines)
 }


### PR DESCRIPTION
## Summary

Hotfix для v0.9.1 (BL-7). Изначальный фикс был неполным: использовал
**логический-row** offset (slice по задачам), но это работает только
если каждая задача = 1 строка на экране. При wrap'нутых title'ах
(`wrapTitleColumn` делает multi-line строки) рендер выдаёт больше
визуальных строк чем visibleCount, lipgloss `MaxHeight` обрезает
снизу, и курсор реально невидим.

Unit-тесты v0.9.1 проходили потому что проверяли `m.scrollOffset`
bookkeeping, но **никогда не звали `m.View()`** — поэтому реальный
bug ускользнул. **Новые тесты grep'ают cursor marker `> ` в
выходе `m.View()`** с реалистичными terminal dimensions, wrap'ами
и dual-pane.

## What changed

- **Render math: logical-row → line-space windowing.** Рендерим все
  задачи, трекаем `cursorLineIdx` в `[]string` output, потом
  `windowLines(lines, cursorLineIdx, visibleRows, scrolloff=3)`.
- Helper `windowLines` обрабатывает narrow-window (visible <
  2*scrolloff+1) через hard-bounds re-anchor — PBT поймал
  edge case с visible=1.
- Удалены Model-поля `scrollOffset`/`projectScrollOffset` (теперь
  derived per-render, не stored state) и handler-обновления.
- Удалён `ensureCursorVisible` helper — больше не нужен.

## Tests

11 новых:
- 6 unit для `windowLines` (FitsInVisible, VisibleZero, CursorMissing,
  CursorAtStart/End/Middle, NarrowVisible).
- 1 PBT `TestProp_WindowLines_CursorAlwaysInside` — поймал narrow-window
  bug в первой версии.
- 4 real-render integration: NoWrap, **LongTitlesWrap (тот самый случай)**,
  DualPane, SmallTerminal.
- + project list / project tasks zoom render-tests.
- + BodyLineCountBounded (гарантирует что body не превышает visibleRows).

Удалены тесты v0.9.1 которые проверяли только `m.scrollOffset` bookkeeping.

## Why v0.9.1 missed this

> «Unit-тесты прошли, потому что я проверял только bookkeeping. Real
> bug может быть в `wrapTitleColumn` + lipgloss `MaxHeight` clamp.»

Урок: для render-bug fix нужны **render-based тесты**, не state-based.
Документация по `teatest` от Charmbracelet рассмотрена для будущего
использования (golden file snapshots с реальным `tea.Program` event loop).

## Test plan

- [ ] `task test` — все зелёные
- [ ] `task test-race` — все зелёные
- [ ] `task build` — успешно
- [ ] `task lint` — 0 issues
- [ ] **Manual: открыть Inbox с задачами длиннее title-column (например
      40+ символов), нажать `j` 20+ раз — курсор всегда виден**
- [ ] Manual: то же для screenProjects и screenProjectTasks zoom