### PR TITLE
fix(tui): page long lists with PgUp/PgDown + Things 3 roadmap

### DIFF
--- a/.spec/BACKLOG.md
+++ b/.spec/BACKLOG.md
@@ -78,6 +78,80 @@ area picker — deferred v2 (если понадобятся, отдельный
 — пользователь не видит, что выбрано. Нужен viewport со
 scroll-offset, который следит за курсором (edge-follow + scrolloff).
 
+## Things 3 parity (роадмап)
+
+Цель — приблизить TUI к ощущению Things 3. Ключевой факт: доменный слой
+уже моделирует почти весь Things (`task.Task`: `AreaID`, `ProjectID`,
+`HeadingID`, `Tags`, `StartDate`=When, `Deadline`, `Someday`,
+`PinnedToday`, `Checklist`, `Repeat`; `project.Project`:
+`Deadline`/`AutoClose`/`Headings`; все шесть списков в `internal/app`).
+Поэтому работа почти целиком в presentation-слое (`internal/tui`), новых
+схем почти не требуется.
+
+Вне scope для TUI: drag «Magic Plus», слияние событий OS-календаря,
+анимации. Capture через quick-entry (`#tag @today @project !date`) уже
+закрывает сценарий быстрого ввода.
+
+### Фаза A — визуальная идентичность (fast-track, без смены архитектуры)
+
+#### BL-9 — Progress ring у проектов
+`projectCounts [open,total]` / `CountProjectTasks` уже есть; сейчас
+показываются числом. Рендерить как кольцо прогресса (○ ◔ ◑ ◕ ●) рядом с
+именем проекта в `internal/tui/project_list.go` (опц. агрегат по area
+позже). Чистый рендер, без новых данных.
+
+#### BL-10 — Визуальные маркеры Today
+Жёлтая звезда у задач Today, когда они видны в Anytime; иконка-луна для
+This Evening (готовим под BL-12); полировка глифов completed/cancelled
+в `viewList` (`internal/tui/app.go`), акценты и воздух. Опирается на
+палитру в `internal/tui/style.go`.
+
+### Фаза B — точность планирования (концептуальное ядро Things)
+
+#### BL-11 — Богатый «When» picker (overlay)
+Сейчас редактор (`fieldWhen`, `internal/tui/editor.go`) переключает лишь
+Anytime↔Someday. Нужен overlay-пикер: Today / This Evening / выбрать
+дату / Someday / очистить — по образцу `areaPicker` (BL-8,
+`internal/tui/area_picker.go`). Пишет в `StartDate`/`Someday`/новое
+поле This Evening.
+
+#### BL-12 — Зона This Evening в Today
+Новое состояние (флаг на задаче или производное от StartDate) +
+разделитель в списке Today (дневные сверху, вечерние снизу под луной) +
+toggle показа. Зависит от BL-11 (общий выбор состояния When).
+
+#### BL-13 — Группировка Upcoming по дням и Logbook по датам
+Сейчас списки плоские. Добавить заголовки-группы по дате в рендере
+`ListUpcoming`/`ListLogbook`. Logbook — по дате завершения, различать
+completed/cancelled визуально.
+
+### Фаза C — структура и группировка
+
+#### BL-14 — Headings: рендер по группам + CRUD
+Отложенная половина BL-5. Группировать задачи проекта под headings в
+`internal/tui/project_tasks.go`; CRUD heading (домен `Heading`,
+`HeadingID`, кэш `headingNamesByID` уже есть). Drag-группы — N/A в TUI,
+вместо этого move-под-heading клавишами.
+
+#### BL-15 — Tag filter bar (чипы) + фильтр по тегам
+Сейчас `/`-фильтр — это regex по заголовку (`internal/tui/filter.go`).
+Добавить строку чипов активных тегов сверху списка + фильтрацию по
+выбранному тегу (теги уже в домене и в details).
+
+#### BL-16 — Inline-редактирование чеклиста
+`task.Checklist []ChecklistItem` уже есть; добавить добавление /
+переключение / удаление пунктов прямо в task editor
+(`internal/tui/editor.go`).
+
+### Фаза D — постоянный сайдбар (определяющий лейаут, крупнейший рефактор)
+
+#### BL-17 — Persistent sidebar
+Заменить header-tabs + отдельный `screenProjects` на левый сайдбар
+(шесть списков + дерево Areas→Projects) | основной список | details.
+Затрагивает монолитный `Model` (63 поля) и dispatch во `View`
+(`internal/tui/app.go`). Делать последним; желательно после выделения
+саб-компонентов. Высокий payoff, высокий риск.
+
 ## Группировка для планирования (предложение)
 
 Можно сгруппировать в 3 будущих feature-pipeline'а:
@@ -94,7 +168,13 @@ scroll-offset, который следит за курсором (edge-follow + 
 
 4. ~~**area-picker** (BL-8)~~ ✅ done — full pipeline. Общий
    `areaPicker` компонент + интеграция в оба редактора + inline-create.
-   Бэклог снова пуст; ждём новых идей.
+
+Things 3 parity (новые pipeline'ы, по фазам — порядок = приоритет):
+
+5. **things-visual** (BL-9, BL-10) — фаза A, fast-track, без архитектуры.
+6. **things-scheduling** (BL-11, BL-12, BL-13) — фаза B, full pipeline.
+7. **things-structure** (BL-14, BL-15, BL-16) — фаза C, можно дробить.
+8. **things-sidebar** (BL-17) — фаза D, крупный рефактор, последним.
 
 Решение по группировке остаётся за пользователем; список выше —
 рекомендация для удобства.

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -345,6 +345,12 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.cursor++
 		}
 		return m, nil
+	case key.Matches(msg, m.keys.PageUp):
+		m.cursor = clampCursor(m.cursor-pageStep(m), len(m.tasks))
+		return m, nil
+	case key.Matches(msg, m.keys.PageDown):
+		m.cursor = clampCursor(m.cursor+pageStep(m), len(m.tasks))
+		return m, nil
 	case key.Matches(msg, m.keys.Enter):
 		return m.openEditor()
 	case key.Matches(msg, m.keys.QuickEntry):
@@ -512,6 +518,12 @@ func (m Model) handleProjectsKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.projectCursor++
 		}
 		return m, nil
+	case key.Matches(msg, m.keys.PageUp):
+		m.projectCursor = clampCursor(m.projectCursor-pageStep(m), len(displayedProjects(m)))
+		return m, nil
+	case key.Matches(msg, m.keys.PageDown):
+		m.projectCursor = clampCursor(m.projectCursor+pageStep(m), len(displayedProjects(m)))
+		return m, nil
 	case key.Matches(msg, m.keys.Filter):
 		m.filtering = true
 		m.filterQuery = ""
@@ -651,6 +663,12 @@ func (m Model) handleProjectTasksKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if m.cursor < len(m.tasks)-1 {
 			m.cursor++
 		}
+		return m, nil
+	case key.Matches(msg, m.keys.PageUp):
+		m.cursor = clampCursor(m.cursor-pageStep(m), len(m.tasks))
+		return m, nil
+	case key.Matches(msg, m.keys.PageDown):
+		m.cursor = clampCursor(m.cursor+pageStep(m), len(m.tasks))
 		return m, nil
 	case key.Matches(msg, m.keys.Enter):
 		return m.openEditor()
@@ -1089,7 +1107,7 @@ func (m Model) viewHelp() string {
 	binds := []key.Binding{
 		m.keys.Help, m.keys.Quit,
 		m.keys.Inbox, m.keys.Today, m.keys.Upcoming, m.keys.Anytime, m.keys.Someday, m.keys.Logbook,
-		m.keys.Up, m.keys.Down,
+		m.keys.Up, m.keys.Down, m.keys.PageUp, m.keys.PageDown,
 		m.keys.QuickEntry, m.keys.Complete, m.keys.Cancel, m.keys.Delete, m.keys.PinToday, m.keys.Refresh,
 		m.keys.Filter, m.keys.ToggleSelect, m.keys.SelectAll, m.keys.ClearSelection,
 	}

--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -13,6 +13,8 @@ type KeyMap struct {
 	Logbook           key.Binding
 	Up                key.Binding
 	Down              key.Binding
+	PageUp            key.Binding
+	PageDown          key.Binding
 	Enter             key.Binding
 	QuickEntry        key.Binding
 	Complete          key.Binding
@@ -46,6 +48,8 @@ func DefaultKeyMap() KeyMap {
 		Logbook:           key.NewBinding(key.WithKeys("6"), key.WithHelp("6", "Logbook")),
 		Up:                key.NewBinding(key.WithKeys("k", "up"), key.WithHelp("k / ↑", "up")),
 		Down:              key.NewBinding(key.WithKeys("j", "down"), key.WithHelp("j / ↓", "down")),
+		PageUp:            key.NewBinding(key.WithKeys("pgup", "ctrl+b"), key.WithHelp("PgUp / Ctrl+B", "page up")),
+		PageDown:          key.NewBinding(key.WithKeys("pgdown", "ctrl+f"), key.WithHelp("PgDn / Ctrl+F", "page down")),
 		Enter:             key.NewBinding(key.WithKeys("enter"), key.WithHelp("enter", "details")),
 		QuickEntry:        key.NewBinding(key.WithKeys("n"), key.WithHelp("n", "quick entry")),
 		Complete:          key.NewBinding(key.WithKeys("c"), key.WithHelp("c", "complete")),

--- a/internal/tui/viewport.go
+++ b/internal/tui/viewport.go
@@ -63,6 +63,28 @@ func windowLines(lines []string, cursorLineIdx, visibleRows, scrolloff int) stri
 	return strings.Join(lines[start:end], "\n")
 }
 
+// pageStep reports how many rows PgUp/PgDown moves the cursor: one
+// bodyful of rows (visibleRows). Falls back to a sane default before the
+// first WindowSizeMsg so paging still works when the terminal size is
+// not yet known.
+func pageStep(m Model) int {
+	if v := visibleRows(m); v > 0 {
+		return v
+	}
+	return 10
+}
+
+// clampCursor bounds idx to [0, n-1]; returns 0 when n <= 0.
+func clampCursor(idx, n int) int {
+	if n <= 0 || idx < 0 {
+		return 0
+	}
+	if idx > n-1 {
+		return n - 1
+	}
+	return idx
+}
+
 // visibleRows reports how many list rows can be rendered in the body
 // pane: m.height - height(viewHeader) - height(viewFooter) - 2
 // (two separator rows). Returns 0 before the first WindowSizeMsg

--- a/internal/tui/viewport_test.go
+++ b/internal/tui/viewport_test.go
@@ -256,3 +256,97 @@ func TestModel_ViewList_BodyLineCountBounded(t *testing.T) {
 		"viewList body must not exceed visibleRows (%d), got %d lines",
 		visibleRows(m), bodyLines)
 }
+
+// ─── PgUp/PgDown paging ──────────────────────────────────────────────
+
+func openTaskModel(t *testing.T, n int) Model {
+	t.Helper()
+	m := newTestModel(t)
+	m.height = 20
+	m.width = 80
+	tasks := make([]task.Task, n)
+	for i := range tasks {
+		tasks[i] = task.Task{ID: id.New(), Title: fmt.Sprintf("t-%03d", i), Status: task.StatusOpen}
+	}
+	m.tasks = tasks
+	return m
+}
+
+func TestModel_PageDown_AdvancesByOnePage(t *testing.T) {
+	m := openTaskModel(t, 100)
+	step := pageStep(m)
+	require.Greater(t, step, 0)
+	mm, _ := m.Update(tea.KeyMsg{Type: tea.KeyPgDown})
+	m = mm.(Model)
+	require.Equal(t, step, m.cursor)
+}
+
+func TestModel_PageUp_RetreatsByOnePage(t *testing.T) {
+	m := openTaskModel(t, 100)
+	m.cursor = 99
+	step := pageStep(m)
+	mm, _ := m.Update(tea.KeyMsg{Type: tea.KeyPgUp})
+	m = mm.(Model)
+	require.Equal(t, 99-step, m.cursor)
+}
+
+func TestModel_PageDown_ClampsAtEnd(t *testing.T) {
+	m := openTaskModel(t, 5) // fewer rows than a page
+	mm, _ := m.Update(tea.KeyMsg{Type: tea.KeyPgDown})
+	m = mm.(Model)
+	require.Equal(t, 4, m.cursor)
+}
+
+func TestModel_PageUp_ClampsAtStart(t *testing.T) {
+	m := openTaskModel(t, 100)
+	m.cursor = 2
+	mm, _ := m.Update(tea.KeyMsg{Type: tea.KeyPgUp})
+	m = mm.(Model)
+	require.Equal(t, 0, m.cursor)
+}
+
+func TestModel_PageDown_EmptyListStaysZero(t *testing.T) {
+	m := openTaskModel(t, 0)
+	mm, _ := m.Update(tea.KeyMsg{Type: tea.KeyPgDown})
+	m = mm.(Model)
+	require.Equal(t, 0, m.cursor)
+}
+
+func TestModel_PageDown_ProjectsScreen(t *testing.T) {
+	m := newTestModel(t)
+	m.screen = screenProjects
+	m.height = 20
+	m.width = 80
+	projects := make([]project.Project, 100)
+	for i := range projects {
+		projects[i] = project.Project{ID: id.New(), Name: fmt.Sprintf("p-%03d", i), Status: project.StatusOpen}
+	}
+	m.projects = projects
+	step := pageStep(m)
+	mm, _ := m.Update(tea.KeyMsg{Type: tea.KeyPgDown})
+	m = mm.(Model)
+	require.Equal(t, step, m.projectCursor)
+}
+
+func TestModel_PageDown_ProjectTasksScreen(t *testing.T) {
+	m := openTaskModel(t, 100)
+	pid := id.New()
+	m.screen = screenProjectTasks
+	m.activeProjectID = &pid
+	m.projectTasks = m.tasks
+	step := pageStep(m)
+	mm, _ := m.Update(tea.KeyMsg{Type: tea.KeyPgDown})
+	m = mm.(Model)
+	require.Equal(t, step, m.cursor)
+}
+
+func TestModel_PageDown_CursorStaysVisible(t *testing.T) {
+	lipgloss.SetColorProfile(termenv.Ascii)
+	t.Cleanup(func() { lipgloss.SetColorProfile(termenv.Ascii) })
+
+	m := openTaskModel(t, 100)
+	mm, _ := m.Update(tea.KeyMsg{Type: tea.KeyPgDown})
+	m = mm.(Model)
+	require.NotEmpty(t, findCursorLine(m.View()),
+		"cursor marker must remain visible after PgDown")
+}


### PR DESCRIPTION
## Summary
- **PgUp/PgDown paging** for long lists — jumps the cursor one bodyful of rows, clamped to bounds, riding on the existing `windowLines` viewport. Works on GTD lists, the project-tasks zoom view, and the projects screen. Bindings: `PgUp`/`Ctrl+B`, `PgDn`/`Ctrl+F` (Ctrl aliases because some terminals capture PgUp/PgDn for scrollback).
- **Things 3 parity roadmap** added to `.spec/BACKLOG.md` as BL-9..BL-17, grouped into 4 phases (visual / scheduling / structure / sidebar). Planning only — no behavior change from this part.

## Implementation
- `internal/tui/keys.go` — new `PageUp`/`PageDown` bindings.
- `internal/tui/viewport.go` — `pageStep(m)` (one `visibleRows`, fallback 10) and `clampCursor(idx, n)`.
- `internal/tui/app.go` — paging cases in all three list handlers; bindings listed in the help screen.
- `internal/tui/viewport_test.go` — 8 new tests (advance/retreat by a page, clamp both ends, empty list, projects + project-tasks screens, cursor-stays-visible).

## Test plan
- [x] `go build ./...`
- [x] `go vet ./internal/tui/`
- [x] `gofmt -l internal/tui/` (clean)
- [x] `go test ./... -count=1` (all packages green)